### PR TITLE
Add connection options to MongoDriver

### DIFF
--- a/lib/health-indicator/database/typeorm.health.ts
+++ b/lib/health-indicator/database/typeorm.health.ts
@@ -77,8 +77,8 @@ export class TypeOrmHealthIndicator extends HealthIndicator {
       const driver = connection.driver as any;
       // Hacky workaround which uses the native MongoClient
       driver.mongodb.MongoClient.connect(
-        driver.buildConnectionUrl(),
-        driver.buildConnectionOptions(),
+        driver.buildConnectionUrl(connection.options),
+        driver.buildConnectionOptions(connection.options),
         (err: Error, client: any) => {
           if (err) return reject(new MongoConnectionError(err.message));
           client.close(() => resolve());


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The TypeORM MongoDriver functions `buildConnectionUrl` and `buildConnectionOptions` expects the options object which is currently not being passed to the functions in `typeorm.health.ts:80-81`.

This results in an exception being thrown by `driver.mongodb.MongoClient.connect` and gives incorrect indication that the database is down.

Issue Number: N/A


## What is the new behavior?
The options object from the connection is passed the the functions in order to create a connections to the MongoDB to correctly determine if the database is up or down.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information