### PR TITLE
fix: broaden HealthIndicatorFunction types

### DIFF
--- a/lib/health-indicator/health-indicator.ts
+++ b/lib/health-indicator/health-indicator.ts
@@ -5,7 +5,9 @@ import { HealthIndicatorResult } from './';
  *
  * @publicApi
  */
-export type HealthIndicatorFunction = () => Promise<HealthIndicatorResult>;
+export type HealthIndicatorFunction = () =>
+  | PromiseLike<HealthIndicatorResult>
+  | HealthIndicatorResult;
 
 /**
  * Represents an abstract health indicator


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`HealthIndicatorFunction`s must return a `Promise<HealthIndicatorResult>`. Synchronous functions are not allowed.

Issue Number: N/A


## What is the new behavior?

`HealthIndicatorFunction`s can return a `PromiseLike<HealthIndicatorResult>` (ex. Bluebird promises) or can be synchronous.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
