### PR TITLE
feat: expose `HealthCheckStatus` public type

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,5 +5,6 @@ export {
   HealthCheck,
   HealthCheckService,
   HealthCheckError,
+  HealthCheckStatus,
   HealthCheckResult,
 } from './health-check';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If we want to import the type `HealthCheckStatus`, we'll need to write  
`import type { HealthCheckStatus } from '@nestjs/terminus/dist/health-check'`  
or  
`HealthCheckResult['status']`


## What is the new behavior?

I'm not sure if this was intention because there's a `@publicApi` annotation on that type

https://github.com/nestjs/terminus/blob/11ef36467001063a7471f5b8227257248b16eecb/lib/health-check/health-check-result.interface.ts#L3-L6

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
