### PR TITLE
chore(manifest): add optional peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,56 @@
     "@nestjs/common": "9.x",
     "@nestjs/core": "9.x",
     "reflect-metadata": "0.1.x",
-    "rxjs": "7.x"
+    "rxjs": "7.x",
+    "@nestjs/microservices": "*",
+    "@grpc/grpc-js": "*",
+    "@grpc/proto-loader": "*",
+    "@nestjs/axios": "*",
+    "@mikro-orm/nestjs": "*",
+    "@mikro-orm/core": "*",
+    "@nestjs/mongoose": "*",
+    "@nestjs/sequelize": "*",
+    "@nestjs/typeorm": "*",
+    "mongoose": "*",
+    "sequelize": "*",
+    "typeorm": "*"
+  },
+  "peerDependenciesMeta": {
+    "@nestjs/microservices": {
+      "optional": true
+    },
+    "@grpc/grpc-js": {
+      "optional": true
+    },
+    "@grpc/proto-loader": {
+      "optional": true
+    },
+    "@nestjs/axios": {
+      "optional": true
+    },
+    "@mikro-orm/nestjs": {
+      "optional": true
+    },
+    "@mikro-orm/core": {
+      "optional": true
+    },
+    "@nestjs/mongoose": {
+      "optional": true
+    },
+    "@nestjs/sequelize": {
+      "optional": true
+    },
+    "@nestjs/typeorm": {
+      "optional": true
+    },
+    "mongoose": {
+      "optional": true
+    },
+    "sequelize": {
+      "optional": true
+    },
+    "typeorm": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
closes #2071

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/terminus/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

Issue Number: #2071

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## More Info

I gathered all usages of the `checkPackages` function to see what packages it could be called with, and added those as optional peerDeps.

We could (and probably should) specify what versions are compatible, but I lack the knowledge to do that. Adding them as `"*"` is already an improvement.