### PR TITLE
fix: Fix crash when setting logger to false

### DIFF
--- a/lib/health-check/health-check.service.spec.ts
+++ b/lib/health-check/health-check.service.spec.ts
@@ -4,7 +4,7 @@ import { HealthCheckExecutor } from './health-check-executor.service';
 import { ERROR_LOGGER } from './error-logger/error-logger.provider';
 import { ErrorLogger } from './error-logger/error-logger.interface';
 import { TERMINUS_LOGGER } from './logger/logger.provider';
-import { ConsoleLogger } from '@nestjs/common';
+import { ConsoleLogger, LoggerService } from '@nestjs/common';
 
 const healthCheckExecutorMock: Partial<HealthCheckExecutor> = {
   execute: jest.fn(),
@@ -14,8 +14,7 @@ const errorLoggerMock: ErrorLogger = {
   getErrorMessage: jest.fn(),
 };
 
-const loggerMock: Partial<ConsoleLogger> = {
-  setContext: jest.fn(),
+const loggerMock: Partial<LoggerService> = {
   log: jest.fn(),
   error: jest.fn(),
   warn: jest.fn(),
@@ -25,7 +24,7 @@ const loggerMock: Partial<ConsoleLogger> = {
 describe('HealthCheckService', () => {
   let healthCheckExecutor: HealthCheckExecutor;
   let healthCheckService: HealthCheckService;
-  let logger: ConsoleLogger;
+  let logger: LoggerService;
   let errorLogger: ErrorLogger;
 
   beforeEach(async () => {

--- a/lib/health-check/health-check.service.ts
+++ b/lib/health-check/health-check.service.ts
@@ -3,6 +3,7 @@ import {
   ServiceUnavailableException,
   Inject,
   ConsoleLogger,
+  LoggerService,
 } from '@nestjs/common';
 import { HealthIndicatorFunction } from '../health-indicator';
 import { ErrorLogger } from './error-logger/error-logger.interface';
@@ -22,9 +23,11 @@ export class HealthCheckService {
     @Inject(ERROR_LOGGER)
     private readonly errorLogger: ErrorLogger,
     @Inject(TERMINUS_LOGGER)
-    private readonly logger: ConsoleLogger,
+    private readonly logger: LoggerService,
   ) {
-    this.logger.setContext(HealthCheckService.name);
+    if (this.logger instanceof ConsoleLogger) {
+      this.logger.setContext(HealthCheckService.name);
+    }
   }
 
   /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/terminus/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When setting up the terminus module with logging disabled according to the [documentation](https://github.com/nestjs/docs.nestjs.com/blob/master/content/recipes/terminus.md?plain=1#L573):
```
TerminusModule.forRoot({ logger: false })
```

the application will crash, with the following error:

```
Error starting application TypeError: this.logger.setContext is not a function
    at new HealthCheckService (/app/node_modules/@nestjs/terminus/dist/health-check/health-check.service.js:39:21)
```

This is caused by incorrect typing of the logger injected into `HealthCheckService`. It's typed to be a `ConsoleLogger`, which is why it looks safe to call `setContext`.

This is **not** true when passing `{logger: false}`, and probably not when using a customer logger either.

## What is the new behavior?

Setting up the terminus module with logging disabled no longer crashes the app :)

If a `ConsoleLogger` is provided, we still call `setContext` in order to preserve the old behavior. I guess we could consider calling `setContext` as long as it exists on the logger object instead?

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
