### PR TITLE
fix: missing setContext when using logger: false

### DIFF
--- a/lib/health-indicator/http/http.health.ts
+++ b/lib/health-indicator/http/http.health.ts
@@ -33,7 +33,9 @@ export class HttpHealthIndicator extends HealthIndicator {
     private readonly logger: ConsoleLogger,
   ) {
     super();
-    this.logger.setContext(HttpHealthIndicator.name);
+    if (this.logger instanceof ConsoleLogger) {
+      this.logger.setContext(HttpHealthIndicator.name);
+    }
     this.checkDependantPackages();
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/terminus/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

HealthIndicator assumes it gets a ConsoleLogger, but TERMINUS_LOGGER is only guaranteed to be an instance of LoggerService which doesn't have a setContext method. This breaks when using logger: false.

> [Nest] 1  - 03/20/2023, 7:37:21 AM   ERROR [ExceptionHandler] this.logger.setContext is not a function
TypeError: this.logger.setContext is not a function
    at new HttpHealthIndicator (/opt/app-root/src/.yarn/__virtual__/@nestjs-terminus-virtual-50e9f71c76/0/cache/@nestjs-terminus-npm-9.2.1-a0864fdc23-ac09b7fced.zip/node_modules/@nestjs/terminus/dist/health-indicator/http/http.health.js:60:21)
    at Injector.instantiateClass (/opt/app-root/src/.yarn/unplugged/@nestjs-core-virtual-a42986c2d9/node_modules/@nestjs/core/injector/injector.js:351:19)
    at callback (/opt/app-root/src/.yarn/unplugged/@nestjs-core-virtual-a42986c2d9/node_modules/@nestjs/core/injector/injector.js:56:45)
    at async Injector.resolveConstructorParams (/opt/app-root/src/.yarn/unplugged/@nestjs-core-virtual-a42986c2d9/node_modules/@nestjs/core/injector/injector.js:136:24)
    at async Injector.loadInstance (/opt/app-root/src/.yarn/unplugged/@nestjs-core-virtual-a42986c2d9/node_modules/@nestjs/core/injector/injector.js:61:13)
    at async Injector.loadProvider (/opt/app-root/src/.yarn/unplugged/@nestjs-core-virtual-a42986c2d9/node_modules/@nestjs/core/injector/injector.js:88:9)
    at async Injector.lookupComponentInImports (/opt/app-root/src/.yarn/unplugged/@nestjs-core-virtual-a42986c2d9/node_modules/@nestjs/core/injector/injector.js:281:17)
    at async Injector.lookupComponentInParentModules (/opt/app-root/src/.yarn/unplugged/@nestjs-core-virtual-a42986c2d9/node_modules/@nestjs/core/injector/injector.js:245:33)
    at async Injector.resolveComponentInstance (/opt/app-root/src/.yarn/unplugged/@nestjs-core-virtual-a42986c2d9/node_modules/@nestjs/core/injector/injector.js:200:33)
    at async resolveParam (/opt/app-root/src/.yarn/unplugged/@nestjs-core-virtual-a42986c2d9/node_modules/@nestjs/core/injector/injector.js:120:38)

Same issue that was fixed in https://github.com/nestjs/terminus/pull/2225 but for health-indicator/http

Issue Number: N/A

## What is the new behavior?

Avoid crash by checking that logger is instance of ConsoleLogger before calling setContext


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
