### PR TITLE
docs(README): update `npm install` to include --legacy-peer-deps option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Setup the development environment by following these instructions:
 2. Install the dependencies
 
 ```bash
-npm install
+npm install --legacy-peer-deps
 
 # To rebuild the project, run
 npm run build


### PR DESCRIPTION
I clone the repo and tried to run it locally, but the `npm install` was throwing errors with `micro-orm`:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR!
npm ERR! While resolving: @mikro-orm/nestjs@5.1.8
```

I noticed that the GitHub workflows use the ` --legacy-peer-deps` option, so I suggest adding this to the `README` for anyone else trying to contribute to the repo.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/terminus/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Documentation changes

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
