### PR TITLE
chore: export `HealthCheckExecutor`

### DIFF
--- a/lib/health-check/index.ts
+++ b/lib/health-check/index.ts
@@ -1,4 +1,5 @@
 export * from './health-check.service';
 export * from './health-check.decorator';
+export * from './health-check-executor.service';
 export * from './health-check-result.interface';
 export * from './health-check.error';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -8,4 +8,5 @@ export {
   HealthCheckError,
   HealthCheckStatus,
   HealthCheckResult,
+  HealthCheckExecutor,
 } from './health-check';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/terminus/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Exporting missing HealthCheckExecutor

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When writing unit tests for a HealthCheckController that uses Terminus, I found out that it is a bit difficult to instantiate the testing module without the `HealthCheckExecutor`.

A test module like this:

```
const logger = createMock<LoggerService>();

const metadata = {
  controllers: [HealthController],
  providers: [
    HealthCheckService,
    { provide: 'TERMINUS_LOGGER', useValue: logger },
    { provide: 'TERMINUS_ERROR_LOGGER', useValue: logger },
  ],
};

const module = await Test.createTestingModule(metadata)
  .compile();
```

Throws the following error:

```
    Nest can't resolve dependencies of the HealthCheckService (?, TERMINUS_ERROR_LOGGER, TERMINUS_LOGGER). Please make sure that the argument HealthCheckExecutor at index [0] is available in the RootTestModule context.

    Potential solutions:
    - Is RootTestModule a valid NestJS module?
    - If HealthCheckExecutor is a provider, is it part of the current RootTestModule?
    - If HealthCheckExecutor is exported from a separate @Module, is that module imported within RootTestModule?
      @Module({
        imports: [ /* the Module containing HealthCheckExecutor */ ]
      })
```

## What is the new behavior?

With the new behaviour, I can write unit test for a HealthCheckController by adding the `HealthCheckExecutor` to the list of providers:

```
const metadata = {
  controllers: [HealthController],
  providers: [
    HealthCheckService,
    HealthCheckExecutor,
    { provide: 'TERMINUS_LOGGER', useValue: logger },
    { provide: 'TERMINUS_ERROR_LOGGER', useValue: logger },
  ],
};
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
