### PR TITLE
fix(mikro-orm.health): mikro-orm connection `type` is deprecated

### DIFF
--- a/lib/health-indicator/database/mikro-orm.health.ts
+++ b/lib/health-indicator/database/mikro-orm.health.ts
@@ -1,6 +1,6 @@
-import { Injectable, NotImplementedException, Scope } from '@nestjs/common';
+import { Injectable, Scope } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
-import { HealthCheckError } from '../../health-check/health-check.error';
+import { HealthCheckError } from '../../health-check';
 
 import * as MikroOrm from '@mikro-orm/core';
 import { TimeoutError } from '../../errors';
@@ -121,24 +121,7 @@ export class MikroOrmHealthIndicator extends HealthIndicator {
    *
    */
   private async pingDb(connection: MikroOrm.Connection, timeout: number) {
-    let check: Promise<any>;
-    const type = connection.getPlatform().getConfig().get('type');
-
-    switch (type) {
-      case 'postgresql':
-      case 'mysql':
-      case 'mariadb':
-      case 'sqlite':
-        check = connection.execute('SELECT 1');
-        break;
-      case 'mongo':
-        check = connection.isConnected();
-        break;
-      default:
-        throw new NotImplementedException(
-          `${type} ping check is not implemented yet`,
-        );
-    }
-    return await promiseTimeout(timeout, check);
+    const isConnected = connection.isConnected();
+    return await promiseTimeout(timeout, isConnected);
   }
 }


### PR DESCRIPTION
Use the abstraction provided by MikroOrm to determine connection status.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/terminus/blob/master/CONTRIBUTING.md
- [-] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The current implementation relies on 'type' being present, which it no longer will be.

Issue Number: #2259 

## What is the new behavior?
Relying on the MikroOrm.connection.isConnected implementation, which functionally does the same thing, but moves the "supported driver concern" to the library implementing them by using it's abstraction on connections.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

We could be more strict about the current peerDep?
"@mikro-orm/core": "*",
