### PR TITLE
feat: Do not cache health checks per default

### DIFF
--- a/e2e/health-checks/health-check.e2e-spec.ts
+++ b/e2e/health-checks/health-check.e2e-spec.ts
@@ -1,0 +1,26 @@
+import * as request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { DynamicHealthEndpointFn, bootstrapTestingModule } from '../helper';
+import { HealthIndicatorResult } from '../../lib';
+
+describe.only('HealthCheck', () => {
+  let app: INestApplication;
+  let setHealthEndpoint: DynamicHealthEndpointFn;
+
+  const healthyCheck = () =>
+    Promise.resolve<HealthIndicatorResult>({ status: 'up' } as any);
+
+  beforeEach(
+    () => (setHealthEndpoint = bootstrapTestingModule().setHealthEndpoint),
+  );
+
+  it('should set the Cache-Control header to no-cache, no-store, must-revalidate', async () => {
+    app = await setHealthEndpoint(({ healthCheck }) =>
+      healthCheck.check([healthyCheck]),
+    ).start();
+
+    return request(app.getHttpServer())
+      .get('/health')
+      .expect('Cache-Control', 'no-cache, no-store, must-revalidate');
+  });
+});

--- a/lib/health-check/health-check.decorator.ts
+++ b/lib/health-check/health-check.decorator.ts
@@ -1,14 +1,74 @@
+import { Header } from '@nestjs/common';
 import { getHealthCheckSchema } from './health-check.schema';
 
 type Swagger = typeof import('@nestjs/swagger');
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
+/**
+ * @publicApi
+ */
+export interface HealthCheckOptions {
+  /**
+   * Whether to cache the response or not.
+   * - If set to `true`, the response header will be set to `Cache-Control: no-cache, no-store, must-revalidate`.
+   * - If set to `false`, no header will be set and can be set manually with e.g. `@Header('Cache-Control', 'max-age=604800')`.
+   *
+   * @default true
+   */
+  noCache?: boolean;
+  /**
+   * Whether to document the endpoint with Swagger or not.
+   *
+   * @default true
+   */
+  swaggerDocumentation?: boolean;
+}
+
+/**
+ * Marks the endpoint as a Health Check endpoint.
+ *
+ * - If the `@nestjs/swagger` package is installed, the endpoint will be documented.
+ * - Per default, the response will not be cached.
+ *
+ * @publicApi
+ */
+export const HealthCheck = (
+  { noCache, swaggerDocumentation }: HealthCheckOptions = {
+    noCache: true,
+    swaggerDocumentation: true,
+  },
+) => {
+  const decorators: MethodDecorator[] = [];
+
+  if (swaggerDocumentation) {
+    let swagger: Swagger | null = null;
+    try {
+      swagger = require('@nestjs/swagger');
+    } catch {}
+
+    if (swagger) {
+      decorators.push(...getSwaggerDefinitions(swagger));
+    }
+  }
+
+  if (noCache) {
+    const CacheControl = Header(
+      'Cache-Control',
+      'no-cache, no-store, must-revalidate',
+    );
+
+    decorators.push(CacheControl);
+  }
+
+  return (target: any, key: any, descriptor: PropertyDescriptor) => {
+    decorators.forEach((decorator) => {
+      decorator(target, key, descriptor);
+    });
+  };
+};
 
 function getSwaggerDefinitions(swagger: Swagger) {
   const { ApiOkResponse, ApiServiceUnavailableResponse } = swagger;
 
-  // Possible HTTP Status
   const ServiceUnavailable = ApiServiceUnavailableResponse({
     description: 'The Health Check is not successful',
     schema: getHealthCheckSchema('error'),
@@ -19,22 +79,5 @@ function getSwaggerDefinitions(swagger: Swagger) {
     schema: getHealthCheckSchema('ok'),
   });
 
-  // Combine all the SwaggerDecorators
-  return (target: any, key: any, descriptor: PropertyDescriptor) => {
-    ServiceUnavailable(target, key, descriptor);
-    Ok(target, key, descriptor);
-  };
+  return [ServiceUnavailable, Ok];
 }
-
-export const HealthCheck = () => {
-  let swagger: Swagger | null = null;
-  try {
-    // Dynamically load swagger, in case it is not installed
-    swagger = require('@nestjs/swagger');
-  } catch {}
-
-  if (swagger) {
-    return getSwaggerDefinitions(swagger);
-  }
-  return noop;
-};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/terminus/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2328


## What is the new behavior?
When using the `@HealthCheck` decorator
it will now per default set the following header:
`Cache-Control: no-cache, no-store, must-revalidate`

To disable this behavior set `@HealthCheck({ noCache: false })`


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
