### PR TITLE
fix: Fixed typeorm mongodb health check fails with mongodb>=5.0

### DIFF
--- a/lib/health-indicator/database/typeorm.health.ts
+++ b/lib/health-indicator/database/typeorm.health.ts
@@ -79,13 +79,10 @@ export class TypeOrmHealthIndicator extends HealthIndicator {
           ? connection.options.url
           : driver.buildConnectionUrl(connection.options),
         driver.buildConnectionOptions(connection.options),
-        (err: Error, client: any) => {
-          if (err) {
-            return reject(new MongoConnectionError(err.message));
-          }
-          client.close(() => resolve());
-        },
-      );
+      )
+        .catch((err: Error) => reject(new MongoConnectionError(err.message)))
+        .then((client: TypeOrm.MongoClient) => client.close().catch(() => {}))
+        .then(() => resolve());
     });
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/terminus/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
If you try to run a health check for TypeORM with `type: 'mongodb'` with mongodb >= 5.0 you will always get an error:
`{"status":"error","info":{},"error":{"database":{"status":"down","message":"timeout of 5000ms exceeded"}},"details":{"database":{"status":"down","message":"timeout of 5000ms exceeded"}}}` 
It happens because in the `MongoDB` module callback API has been removed. You can read more [here](https://www.mongodb.com/docs/drivers/node/v5.0/whats-new/#std-label-version-5.0).

## What is the new behavior?
With this small fix health check passes

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
