### PR TITLE
feat: graceful shutdown timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ If everything is set up correctly, you can access the healthcheck on `http://loc
 For more information, [see docs](https://docs.nestjs.com/recipes/terminus).
 You can find more samples in the [samples/](https://github.com/nestjs/terminus/tree/master/sample) folder of this repository.
 
+### Graceful shutdown timeout
+
+If your application requires postponing its shutdown process, this can be done by configuring the `gracefulShutdownTimeoutMs` in the `TerminusModule options`. This setting can prove particularly beneficial when working with an orchestrator such as Kubernetes. By setting a delay slightly longer than the readiness check interval, you can achieve zero downtime when shutting down containers.
+
 ## Contribute
 
 In order to get started, first read through our [Contributing guidelines](https://github.com/nestjs/terminus/blob/master/CONTRIBUTING.md).

--- a/lib/graceful-shutdown-timeout/graceful-shutdown-timeout.service.spec.ts
+++ b/lib/graceful-shutdown-timeout/graceful-shutdown-timeout.service.spec.ts
@@ -1,0 +1,47 @@
+import { Test } from '@nestjs/testing';
+import { LoggerService } from '@nestjs/common';
+import {
+  GracefulShutdownTimeoutService,
+  TERMINUS_GRACEFUL_SHUTDOWN_TIMEOUT,
+} from './graceful-shutdown-timeout.service';
+import { TERMINUS_LOGGER } from '../health-check/logger/logger.provider';
+import { sleep } from '../utils';
+
+jest.mock('../utils', () => ({
+  sleep: jest.fn(),
+}));
+
+const loggerMock: Partial<LoggerService> = {
+  log: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+};
+
+describe('GracefulShutdownTimeoutService', () => {
+  let service: GracefulShutdownTimeoutService;
+  let logger: LoggerService;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        GracefulShutdownTimeoutService,
+        { provide: TERMINUS_LOGGER, useValue: loggerMock },
+        { provide: TERMINUS_GRACEFUL_SHUTDOWN_TIMEOUT, useValue: 1000 },
+      ],
+    }).compile();
+
+    logger = module.get(TERMINUS_LOGGER);
+    service = module.get(GracefulShutdownTimeoutService);
+  });
+
+  it('should not trigger sleep if signal is not SIGTERM', async () => {
+    await service.beforeApplicationShutdown('SIGINT');
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('should trigger sleep if signal is SIGTERM', async () => {
+    await service.beforeApplicationShutdown('SIGTERM');
+    expect(sleep).toHaveBeenCalledWith(1000);
+  });
+});

--- a/lib/graceful-shutdown-timeout/graceful-shutdown-timeout.service.spec.ts
+++ b/lib/graceful-shutdown-timeout/graceful-shutdown-timeout.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test } from '@nestjs/testing';
 import { LoggerService } from '@nestjs/common';
 import {
-  GracefulShutdownTimeoutService,
+  GracefulShutdownService,
   TERMINUS_GRACEFUL_SHUTDOWN_TIMEOUT,
 } from './graceful-shutdown-timeout.service';
 import { TERMINUS_LOGGER } from '../health-check/logger/logger.provider';
@@ -18,21 +18,21 @@ const loggerMock: Partial<LoggerService> = {
   debug: jest.fn(),
 };
 
-describe('GracefulShutdownTimeoutService', () => {
-  let service: GracefulShutdownTimeoutService;
+describe('GracefulShutdownService', () => {
+  let service: GracefulShutdownService;
   let logger: LoggerService;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
       providers: [
-        GracefulShutdownTimeoutService,
+        GracefulShutdownService,
         { provide: TERMINUS_LOGGER, useValue: loggerMock },
         { provide: TERMINUS_GRACEFUL_SHUTDOWN_TIMEOUT, useValue: 1000 },
       ],
     }).compile();
 
     logger = module.get(TERMINUS_LOGGER);
-    service = module.get(GracefulShutdownTimeoutService);
+    service = module.get(GracefulShutdownService);
   });
 
   it('should not trigger sleep if signal is not SIGTERM', async () => {

--- a/lib/graceful-shutdown-timeout/graceful-shutdown-timeout.service.ts
+++ b/lib/graceful-shutdown-timeout/graceful-shutdown-timeout.service.ts
@@ -16,9 +16,7 @@ export const TERMINUS_GRACEFUL_SHUTDOWN_TIMEOUT =
  * for some time before the application shuts down.
  */
 @Injectable()
-export class GracefulShutdownService
-  implements BeforeApplicationShutdown
-{
+export class GracefulShutdownService implements BeforeApplicationShutdown {
   constructor(
     @Inject(TERMINUS_LOGGER)
     private readonly logger: LoggerService,
@@ -26,7 +24,7 @@ export class GracefulShutdownService
     private readonly gracefulShutdownTimeoutMs: number,
   ) {
     if (this.logger instanceof ConsoleLogger) {
-      this.logger.setContext(GracefulShutdownTimeoutService.name);
+      this.logger.setContext(GracefulShutdownService.name);
     }
   }
 

--- a/lib/graceful-shutdown-timeout/graceful-shutdown-timeout.service.ts
+++ b/lib/graceful-shutdown-timeout/graceful-shutdown-timeout.service.ts
@@ -16,7 +16,7 @@ export const TERMINUS_GRACEFUL_SHUTDOWN_TIMEOUT =
  * for some time before the application shuts down.
  */
 @Injectable()
-export class GracefulShutdownTimeoutService
+export class GracefulShutdownService
   implements BeforeApplicationShutdown
 {
   constructor(

--- a/lib/graceful-shutdown-timeout/graceful-shutdown-timeout.service.ts
+++ b/lib/graceful-shutdown-timeout/graceful-shutdown-timeout.service.ts
@@ -1,0 +1,44 @@
+import {
+  type BeforeApplicationShutdown,
+  ConsoleLogger,
+  Inject,
+  Injectable,
+  LoggerService,
+} from '@nestjs/common';
+import { TERMINUS_LOGGER } from '../health-check/logger/logger.provider';
+import { sleep } from '../utils';
+
+export const TERMINUS_GRACEFUL_SHUTDOWN_TIMEOUT =
+  'TERMINUS_GRACEFUL_SHUTDOWN_TIMEOUT';
+
+/**
+ * Handles Graceful shutdown timeout useful to await
+ * for some time before the application shuts down.
+ */
+@Injectable()
+export class GracefulShutdownTimeoutService
+  implements BeforeApplicationShutdown
+{
+  constructor(
+    @Inject(TERMINUS_LOGGER)
+    private readonly logger: LoggerService,
+    @Inject('TERMINUS_GRACEFUL_SHUTDOWN_TIMEOUT')
+    private readonly gracefulShutdownTimeoutMs: number,
+  ) {
+    if (this.logger instanceof ConsoleLogger) {
+      this.logger.setContext(GracefulShutdownTimeoutService.name);
+    }
+  }
+
+  async beforeApplicationShutdown(signal: string) {
+    this.logger.log(`Received termination signal ${signal}`);
+
+    if (signal === 'SIGTERM') {
+      this.logger.log(
+        `Awaiting ${this.gracefulShutdownTimeoutMs}ms before shutdown`,
+      );
+      await sleep(this.gracefulShutdownTimeoutMs);
+      this.logger.log(`Timeout reached, shutting down now`);
+    }
+  }
+}

--- a/lib/graceful-shutdown-timeout/graceful-shutdown-timeout.service.ts
+++ b/lib/graceful-shutdown-timeout/graceful-shutdown-timeout.service.ts
@@ -22,7 +22,7 @@ export class GracefulShutdownTimeoutService
   constructor(
     @Inject(TERMINUS_LOGGER)
     private readonly logger: LoggerService,
-    @Inject('TERMINUS_GRACEFUL_SHUTDOWN_TIMEOUT')
+    @Inject(TERMINUS_GRACEFUL_SHUTDOWN_TIMEOUT)
     private readonly gracefulShutdownTimeoutMs: number,
   ) {
     if (this.logger instanceof ConsoleLogger) {

--- a/lib/terminus-options.interface.ts
+++ b/lib/terminus-options.interface.ts
@@ -2,7 +2,15 @@ import { type LoggerService, type Type } from '@nestjs/common';
 
 export type ErrorLogStyle = 'pretty' | 'json';
 
+/**
+ * The Terminus module options
+ *
+ * errorLogStyle: The style of the error logger. Either 'pretty' or 'json'. Default to 'json'.
+ * logger: The logger to use. Either default logger or your own.
+ * gracefulShutdownTimeoutMs: The timeout to wait in ms before the application shuts down. Default to 0ms.
+ */
 export interface TerminusModuleOptions {
   errorLogStyle?: ErrorLogStyle;
   logger?: Type<LoggerService> | boolean;
+  gracefulShutdownTimeoutMs?: number;
 }

--- a/lib/terminus-options.interface.ts
+++ b/lib/terminus-options.interface.ts
@@ -11,6 +11,9 @@ export type ErrorLogStyle = 'pretty' | 'json';
  */
 export interface TerminusModuleOptions {
   errorLogStyle?: ErrorLogStyle;
+  /**
+   * The logger to use. Either default logger or your own.
+   */
   logger?: Type<LoggerService> | boolean;
   /**
    * The timeout to wait in ms before the application shuts down

--- a/lib/terminus-options.interface.ts
+++ b/lib/terminus-options.interface.ts
@@ -8,6 +8,7 @@ export type ErrorLogStyle = 'pretty' | 'json';
  * errorLogStyle: The style of the error logger. Either 'pretty' or 'json'. Default to 'json'.
  * logger: The logger to use. Either default logger or your own.
  * gracefulShutdownTimeoutMs: The timeout to wait in ms before the application shuts down. Default to 0ms.
+ * @publicApi
  */
 export interface TerminusModuleOptions {
   /**

--- a/lib/terminus-options.interface.ts
+++ b/lib/terminus-options.interface.ts
@@ -10,6 +10,10 @@ export type ErrorLogStyle = 'pretty' | 'json';
  * gracefulShutdownTimeoutMs: The timeout to wait in ms before the application shuts down. Default to 0ms.
  */
 export interface TerminusModuleOptions {
+  /**
+   * The style of the error logger
+   * @default 'json'
+   */
   errorLogStyle?: ErrorLogStyle;
   /**
    * The logger to use. Either default logger or your own.

--- a/lib/terminus-options.interface.ts
+++ b/lib/terminus-options.interface.ts
@@ -12,5 +12,9 @@ export type ErrorLogStyle = 'pretty' | 'json';
 export interface TerminusModuleOptions {
   errorLogStyle?: ErrorLogStyle;
   logger?: Type<LoggerService> | boolean;
+  /**
+   * The timeout to wait in ms before the application shuts down
+   * @default 0
+   */
   gracefulShutdownTimeoutMs?: number;
 }

--- a/lib/terminus.module.ts
+++ b/lib/terminus.module.ts
@@ -1,4 +1,5 @@
 import { type DynamicModule, Module } from '@nestjs/common';
+import { TERMINUS_GRACEFUL_SHUTDOWN_TIMEOUT } from './graceful-shutdown-timeout/graceful-shutdown-timeout.service';
 import { HealthCheckService } from './health-check';
 import { getErrorLoggerProvider } from './health-check/error-logger/error-logger.provider';
 import { ERROR_LOGGERS } from './health-check/error-logger/error-loggers.provider';
@@ -30,7 +31,11 @@ const exports_ = [HealthCheckService, ...HEALTH_INDICATORS];
 })
 export class TerminusModule {
   static forRoot(options: TerminusModuleOptions = {}): DynamicModule {
-    const { errorLogStyle = 'json', logger = true } = options;
+    const {
+      errorLogStyle = 'json',
+      logger = true,
+      gracefulShutdownTimeoutMs = 0,
+    } = options;
 
     return {
       module: TerminusModule,
@@ -38,6 +43,10 @@ export class TerminusModule {
         ...providers,
         getErrorLoggerProvider(errorLogStyle),
         getLoggerProvider(logger),
+        {
+          provide: TERMINUS_GRACEFUL_SHUTDOWN_TIMEOUT,
+          useValue: gracefulShutdownTimeoutMs,
+        },
       ],
       exports: exports_,
     };

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -2,3 +2,4 @@ export * from './promise-timeout';
 export * from './checkPackage.util';
 export * from './types';
 export * from './is-error';
+export * from './sleep';

--- a/lib/utils/sleep.ts
+++ b/lib/utils/sleep.ts
@@ -1,0 +1,2 @@
+export const sleep = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/terminus/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/terminus/issues/2421


## What is the new behavior?

Add a new option `gracefulShutdownTimeoutMs` that adds a delay to the application shutdown if specified.

```md
If your application requires postponing its shutdown process, this can be done by configuring the `gracefulShutdownTimeoutMs` in the `TerminusModule options`. 
This setting can prove particularly beneficial when working with an orchestrator such as Kubernetes. 
By setting a delay slightly longer than the readiness check interval, you can achieve zero downtime 
when shutting down containers.
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
