### PR TITLE
fix: responseCheck throwing internal error (#2395)

### DIFF
--- a/lib/health-indicator/http/http.health.ts
+++ b/lib/health-indicator/http/http.health.ts
@@ -146,9 +146,13 @@ export class HttpHealthIndicator extends HealthIndicator {
         httpService.request({ url: url.toString(), ...options }),
       );
     } catch (error) {
-      if (isAxiosError(error) && error.response) {
-        response = error.response;
-        axiosError = error;
+      if (isAxiosError(error)) {
+        if (error.response) {
+          response = error.response;
+          axiosError = error;
+        } else {
+          throw this.generateHttpError(key, error);
+        }
       } else {
         throw error;
       }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/terminus/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When employing the HttpHealthIndicator.responseCheck health indicator, if there's a network error detected in the checked URL, the system fails to handle it appropriately, leading to the health check route throwing a 500 internal error.

Issue Number: #2395

## What is the new behavior?
The system now appropriately handles network errors, ensuring that the health check route no longer results in a 500 internal error.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
