### PR TITLE
fix(@nestjs/terminus): generate the correct openapi health schema

### DIFF
--- a/lib/health-check/health-check.schema.ts
+++ b/lib/health-check/health-check.schema.ts
@@ -17,6 +17,7 @@ const healthIndicatorSchema = (example: HealthIndicatorResult) => ({
   example,
   additionalProperties: {
     type: 'object',
+    required: ['status'],
     properties: {
       status: {
         type: 'string',


### PR DESCRIPTION
When generating the openapi documents 'status' is now marked as required then when generating a typescript client using openapi-generator it translates the healthcheck response to a correct interface. Otherwise the TS2411 compilation error appears.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/terminus/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:
Fix OpenApi schemas.

## What is the current behavior?
Openapi health check response schema has the 'status' property as optional.

## What is the new behavior?
Now the openapi health check response schema has the 'status' property as required.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

