### PR TITLE
feat: Use nest app logger for Terminus per default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 
 
+# [10.3.0-beta.0](https://github.com/nestjs/terminus/compare/10.2.3...10.3.0-beta.0) (2024-07-16)
+
+
+### Features
+
+* **typeorm:** change typeorm mongodb check ([2f0e97d](https://github.com/nestjs/terminus/commit/2f0e97d77c53826012bfe10ebd2ed111e0445cd4))
+* Use nest app logger for Terminus per default ([40c6ec5](https://github.com/nestjs/terminus/commit/40c6ec5868c7838fe4344a563732d0f664cd55c6)), closes [#2547](https://github.com/nestjs/terminus/issues/2547)
+
 ## [10.2.3](https://github.com/nestjs/terminus/compare/10.2.2...10.2.3) (2024-02-18)
 
 

--- a/lib/health-check/logger/default-logger.service.ts
+++ b/lib/health-check/logger/default-logger.service.ts
@@ -1,4 +1,0 @@
-import { Injectable, Scope, ConsoleLogger } from '@nestjs/common';
-
-@Injectable({ scope: Scope.TRANSIENT })
-export class DefaultTerminusLogger extends ConsoleLogger {}

--- a/lib/health-check/logger/logger.provider.ts
+++ b/lib/health-check/logger/logger.provider.ts
@@ -1,32 +1,41 @@
-import { type LoggerService, type Provider, type Type } from '@nestjs/common';
-import { DefaultTerminusLogger } from './default-logger.service';
+import {
+  Logger,
+  type LoggerService,
+  type Provider,
+  type Type,
+} from '@nestjs/common';
 
 export const TERMINUS_LOGGER = 'TERMINUS_LOGGER';
+
+const NOOP_LOGGER = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  log: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  error: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  warn: () => {},
+};
 
 export function getLoggerProvider(
   logger?: Type<LoggerService> | boolean,
 ): Provider<LoggerService> {
+  // Enable logging
   if (logger === true || logger === undefined) {
     return {
       provide: TERMINUS_LOGGER,
-      useClass: DefaultTerminusLogger,
+      useClass: Logger,
     };
   }
 
+  // Disable logging
   if (logger === false) {
     return {
       provide: TERMINUS_LOGGER,
-      useValue: {
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        log: () => {},
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        error: () => {},
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        warn: () => {},
-      },
+      useValue: NOOP_LOGGER,
     };
   }
 
+  // Custom logger
   return {
     provide: TERMINUS_LOGGER,
     useClass: logger,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nestjs/terminus",
-  "version": "10.2.3",
+  "version": "10.3.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nestjs/terminus",
-      "version": "10.2.3",
+      "version": "10.3.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "boxen": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestjs/terminus",
-  "version": "10.2.3",
+  "version": "10.3.0-beta.0",
   "description": "Terminus integration provides readiness/liveness health checks for NestJS.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
It will now use the configured NestJS application logger that has been configured with `app.useLogger(...)`

resolves #2547

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/terminus/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number #2547


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
