### PR TITLE
fix(health-indicator): prevent data.status override

### DIFF
--- a/lib/health-indicator/health-indicator.ts
+++ b/lib/health-indicator/health-indicator.ts
@@ -49,8 +49,8 @@ export abstract class HealthIndicator {
   ): HealthIndicatorResult {
     return {
       [key]: {
-        status: isHealthy ? 'up' : 'down',
         ...data,
+        status: isHealthy ? 'up' : 'down',
       },
     };
   }


### PR DESCRIPTION
## Summary

- Move `status` property after the spread operator in `HealthIndicator.getStatus()` so user data containing a `status` key cannot overwrite the internal health status (`'up'`/`'down'`)
- Aligns the deprecated API with the new `HealthIndicatorSession` which already places `status` after the spread

## Test plan

- [x] All 71 tests pass (7 suites)
- [x] Build passes
- [x] No behavior change for existing usage (no tests pass `data` with `status` key)

Fixes #2668

🤖 Generated with [Claude Code](https://claude.ai/code)