### PR TITLE
fix(http): avoid implicit global HttpService lookup

### DIFF
--- a/lib/health-indicator/http/http.health.integration.spec.ts
+++ b/lib/health-indicator/http/http.health.integration.spec.ts
@@ -1,0 +1,78 @@
+import { Injectable, Module } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { HttpModule, HttpService } from '@nestjs/axios';
+import { of } from 'rxjs';
+import { HttpHealthIndicator } from './http.health';
+import { TerminusModule } from '../../terminus.module';
+
+// https://github.com/nestjs/terminus/issues/2667
+//
+// A health check must never silently pick up an HttpService instance a
+// completely unrelated module configured for its own purposes (wrong
+// baseURL, headers, interceptors, etc). This uses the *real* @nestjs/axios
+// module (unlike http.health.spec.ts, which mocks it) so that the actual
+// NestJS DI graph is exercised, not a mock of it.
+
+const CUSTOM_HTTP_CLIENT_TOKEN = Symbol('CUSTOM_HTTP_CLIENT_TOKEN');
+
+@Module({
+  imports: [
+    HttpModule.registerAsync({
+      useFactory: () => ({ baseURL: 'https://cats.com' }),
+    }),
+  ],
+  providers: [{ provide: CUSTOM_HTTP_CLIENT_TOKEN, useExisting: HttpService }],
+  exports: [CUSTOM_HTTP_CLIENT_TOKEN],
+})
+class UnrelatedApiModule {}
+
+@Injectable()
+class HealthCheckedService {
+  constructor(public readonly http: HttpHealthIndicator) {}
+}
+
+@Module({
+  imports: [TerminusModule],
+  providers: [HealthCheckedService],
+})
+class HealthCheckedModule {}
+
+@Module({ imports: [UnrelatedApiModule] })
+class SomeUnrelatedFeatureModule {}
+
+describe('HttpHealthIndicator (integration, real @nestjs/axios)', () => {
+  it('does not use an HttpService configured by an unrelated module', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [SomeUnrelatedFeatureModule, HealthCheckedModule],
+    }).compile();
+
+    const service = await moduleRef.resolve(HealthCheckedService);
+    const httpService = (service.http as any).getHttpService();
+
+    expect(httpService.axiosRef.defaults.baseURL).toBeUndefined();
+  });
+
+  it('still lets a preconfigured HttpService be used when explicitly passed as httpClient', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [SomeUnrelatedFeatureModule, HealthCheckedModule],
+    }).compile();
+
+    const service = await moduleRef.resolve(HealthCheckedService);
+    const configuredHttpService = moduleRef.get<HttpService>(
+      CUSTOM_HTTP_CLIENT_TOKEN,
+      { strict: false },
+    );
+
+    // pingCheck's `httpClient ||` fallback is what #1151 relies on for reuse
+    // of a preconfigured client - it must remain unaffected by this fix.
+    const requestSpy = jest
+      .spyOn(configuredHttpService, 'request')
+      .mockReturnValue(of({}) as any);
+
+    await service.http.pingCheck('cats', '/some-path', {
+      httpClient: configuredHttpService,
+    });
+
+    expect(requestSpy).toHaveBeenCalled();
+  });
+});

--- a/lib/health-indicator/http/http.health.spec.ts
+++ b/lib/health-indicator/http/http.health.spec.ts
@@ -1,5 +1,5 @@
 import { Test } from '@nestjs/testing';
-import { HttpModule, HttpService } from '@nestjs/axios';
+import { HttpService } from '@nestjs/axios';
 import { HttpHealthIndicator } from './http.health';
 import { checkPackages } from '../../utils/checkPackage.util';
 import { of } from 'rxjs';
@@ -15,13 +15,16 @@ const httpServiceMock = {
 };
 
 const nestJSAxiosMock = {
-  HttpService: httpServiceMock,
+  // getHttpService() does `new this.nestJsAxios.HttpService()`, so this
+  // needs to be a constructor, not a plain object.
+  HttpService: jest.fn().mockImplementation(() => httpServiceMock),
 };
 
 describe('Http Response Health Indicator', () => {
   let httpHealthIndicator: HttpHealthIndicator;
 
   beforeEach(async () => {
+    jest.clearAllMocks();
     (checkPackages as jest.Mock).mockImplementation((): any => [
       nestJSAxiosMock,
     ]);
@@ -29,14 +32,9 @@ describe('Http Response Health Indicator', () => {
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
-      imports: [HttpModule],
       providers: [
         HttpHealthIndicator,
         HealthIndicatorService,
-        {
-          provide: nestJSAxiosMock.HttpService as any,
-          useValue: httpServiceMock,
-        },
         {
           provide: TERMINUS_LOGGER,
           useValue: {
@@ -64,7 +62,8 @@ describe('Http Response Health Indicator', () => {
       await httpHealthIndicator.pingCheck('key', 'url', {
         httpClient,
       });
-      expect(httpServiceMock.request).toHaveBeenCalledWith({ url: 'url' });
+      expect(httpClient.request).toHaveBeenCalledWith({ url: 'url' });
+      expect(httpServiceMock.request).not.toHaveBeenCalled();
     });
 
     it('should throw an error if the response is not an axios error', async () => {

--- a/lib/health-indicator/http/http.health.ts
+++ b/lib/health-indicator/http/http.health.ts
@@ -1,7 +1,6 @@
 import { type URL } from 'url';
 import type * as NestJSAxios from '@nestjs/axios';
 import { ConsoleLogger, Inject, Injectable, Scope } from '@nestjs/common';
-import { ModuleRef } from '@nestjs/core';
 import { lastValueFrom, type Observable } from 'rxjs';
 import { type HealthIndicatorResult } from '..';
 import {
@@ -34,7 +33,6 @@ export class HttpHealthIndicator {
   private nestJsAxios!: typeof NestJSAxios;
 
   constructor(
-    private readonly moduleRef: ModuleRef,
     @Inject(TERMINUS_LOGGER)
     private readonly logger: ConsoleLogger,
     private readonly healthIndicatorService: HealthIndicatorService,
@@ -55,19 +53,18 @@ export class HttpHealthIndicator {
     )[0];
   }
 
-  private getHttpService() {
-    try {
-      return this.moduleRef.get(this.nestJsAxios.HttpService, {
-        strict: false,
-      });
-    } catch (err) {
-      this.logger.error(
-        'It seems like "HttpService" is not available in the current context. Are you sure you imported the HttpModule from the @nestjs/axios package?',
-      );
-      throw new Error(
-        'It seems like "HttpService" is not available in the current context. Are you sure you imported the HttpModule from the @nestjs/axios package?',
-      );
-    }
+  /**
+   * Returns a plain, unconfigured `HttpService` backed by the default axios
+   * instance. This intentionally does not look up any `HttpService` a user
+   * may have registered elsewhere in their application (e.g. via
+   * `HttpModule.register(...)`) - doing so via a global, unscoped DI lookup
+   * previously let a health check silently pick up an unrelated module's
+   * configured axios instance (wrong baseURL, headers, interceptors, etc.).
+   * Pass a `httpClient` explicitly to `pingCheck`/`responseCheck` if you want
+   * to reuse your own preconfigured client.
+   */
+  private getHttpService(): HttpClientLike {
+    return new this.nestJsAxios.HttpService();
   }
 
   /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/terminus/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #2667

`HttpHealthIndicator#getHttpService()` resolves its axios client with `moduleRef.get(HttpService, { strict: false })` - an unscoped, app-wide DI lookup. If any other module in the app has configured its own `HttpService` (e.g. via `HttpModule.register({ baseURL: ... })`, possibly only re-exported under an unrelated token via `useExisting`), a health check can silently end up using that instance instead of a plain client - wrong `baseURL`, headers, interceptors, etc - with nothing to indicate anything went wrong. Which instance gets picked depends on module registration order in Nest's DI container, not anything the caller controls.

## What is the new behavior?

`getHttpService()` no longer performs a DI lookup at all - it returns a plain `new HttpService()` (its own constructor already falls back to axios' global default instance when given no argument). The default path can never observe another module's configuration, because it never looks for one.

Reusing a preconfigured client is still fully supported, just no longer automatic - pass it explicitly via the existing `httpClient` option:

```ts
this.http.pingCheck('x', 'https://example.com', {
  httpClient: this.httpService,
});
```

I also considered keeping the global lookup and only erroring when it finds more than one candidate `HttpService`, which would be a smaller, backward-compatible change. Didn't go with it because it doesn't fix the issue as reported: the reporter's repro has exactly one `HttpService` in the whole app (an unrelated module's), so an ambiguity check alone would still silently pick it up. Open to reconsidering if you'd rather ship the narrower fix first.

Also tried `strict: true` (module-scoped lookup), but it doesn't work here: `HttpHealthIndicator` is declared in `TerminusModule`, which never imports `HttpModule` itself, so a scoped lookup fails even for the currently-documented use case of a consumer relying on auto-discovery (see #1151, referenced directly in the code comment this PR touches) - not just when there's a conflict.

Existing unit tests were updated (the mocked `HttpService` needs to be a constructor now, since `getHttpService()` constructs it). A new `http.health.integration.spec.ts` exercises the real `@nestjs/axios` module across multiple NestJS modules, reproducing the exact leak and confirming the explicit `httpClient` path is unaffected. Also found and fixed a latent bug in the existing "custom httpClient" unit test while reviewing this: it was asserting on the default mock's call history instead of the custom client's, which only "passed" because this test file doesn't clear mocks between tests and an earlier test happened to leave a matching call behind.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

This removes the implicit auto-discovery of a preconfigured `HttpService` referenced by #1151. Before this PR, if your app had exactly one `HttpModule.register(...)` anywhere, `pingCheck`/`responseCheck` would pick it up automatically without you passing `httpClient`. After this PR, that must be explicit.

This is a real tradeoff, not just a cleanup: the current behavior is a documented, requested feature (#1151), and this PR removes its implicit form in favor of always requiring `httpClient`. Explicit-and-predictable seems like the right default here, since the implicit version is exactly what makes the DI lookup unable to distinguish "the user's intended client" from "any other module's client that happens to exist" - but that's a judgment call about the library's API contract, not just a bug fix, and I'd like your take on whether this is the right way to resolve it (vs., say, keeping the automatic behavior for the single-candidate case and only failing loudly on ambiguity).

## Other information

Reverting this fix and running the new integration test reproduces the exact issue (`baseURL` leaks from the unrelated module); with the fix, it doesn't. Full test suite (8 files, 73 tests) and lint pass.
