### PR TITLE
fix(microservice): avoid rmq pingcheck leaving queues behind

### DIFF
--- a/lib/health-indicator/microservice/microservice.health.spec.ts
+++ b/lib/health-indicator/microservice/microservice.health.spec.ts
@@ -1,0 +1,156 @@
+import { Test } from '@nestjs/testing';
+import { Transport } from '@nestjs/microservices';
+import { MicroserviceHealthIndicator } from './microservice.health';
+import { checkPackages } from '../../utils/checkPackage.util';
+import { HealthIndicatorService } from '../health-indicator.service';
+
+jest.mock('../../utils/checkPackage.util');
+
+const clientProxyMock = {
+  connect: jest.fn().mockResolvedValue(undefined),
+  close: jest.fn().mockResolvedValue(undefined),
+};
+
+const clientProxyFactoryMock = {
+  create: jest.fn().mockReturnValue(clientProxyMock),
+};
+
+const nestJSMicroservicesMock = {
+  ClientProxyFactory: clientProxyFactoryMock,
+  Transport,
+};
+
+describe('MicroserviceHealthIndicator', () => {
+  let microservice: MicroserviceHealthIndicator;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    (checkPackages as jest.Mock).mockImplementation((): any => [
+      nestJSMicroservicesMock,
+    ]);
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [MicroserviceHealthIndicator, HealthIndicatorService],
+    }).compile();
+
+    microservice = await moduleRef.resolve(MicroserviceHealthIndicator);
+  });
+
+  describe('#pingCheck', () => {
+    it('does not assert an RMQ queue when no queue options are provided', async () => {
+      await microservice.pingCheck('rmq', {
+        transport: Transport.RMQ,
+        options: {
+          urls: ['amqp://localhost:5672'],
+        },
+      });
+
+      expect(clientProxyFactoryMock.create).toHaveBeenCalledWith({
+        transport: Transport.RMQ,
+        options: {
+          urls: ['amqp://localhost:5672'],
+          noAssert: true,
+        },
+      });
+    });
+
+    it('does not override an explicitly configured RMQ queue', async () => {
+      await microservice.pingCheck('rmq', {
+        transport: Transport.RMQ,
+        options: {
+          urls: ['amqp://localhost:5672'],
+          queue: 'healthcheck.queue',
+        },
+      });
+
+      expect(clientProxyFactoryMock.create).toHaveBeenCalledWith({
+        transport: Transport.RMQ,
+        options: {
+          urls: ['amqp://localhost:5672'],
+          queue: 'healthcheck.queue',
+        },
+      });
+    });
+
+    it('does not override an explicitly configured RMQ noAssert option', async () => {
+      await microservice.pingCheck('rmq', {
+        transport: Transport.RMQ,
+        options: {
+          urls: ['amqp://localhost:5672'],
+          noAssert: false,
+        },
+      });
+
+      expect(clientProxyFactoryMock.create).toHaveBeenCalledWith({
+        transport: Transport.RMQ,
+        options: {
+          urls: ['amqp://localhost:5672'],
+          noAssert: false,
+        },
+      });
+    });
+
+    it('does not override explicitly configured RMQ queue options', async () => {
+      await microservice.pingCheck('rmq', {
+        transport: Transport.RMQ,
+        options: {
+          urls: ['amqp://localhost:5672'],
+          queueOptions: {
+            durable: false,
+          },
+        },
+      });
+
+      expect(clientProxyFactoryMock.create).toHaveBeenCalledWith({
+        transport: Transport.RMQ,
+        options: {
+          urls: ['amqp://localhost:5672'],
+          queueOptions: {
+            durable: false,
+          },
+        },
+      });
+    });
+
+    it('does not override explicitly configured RMQ binding options', async () => {
+      await microservice.pingCheck('rmq', {
+        transport: Transport.RMQ,
+        options: {
+          urls: ['amqp://localhost:5672'],
+          exchange: 'healthcheck.exchange',
+          routingKey: 'healthcheck.route',
+        },
+      });
+
+      expect(clientProxyFactoryMock.create).toHaveBeenCalledWith({
+        transport: Transport.RMQ,
+        options: {
+          urls: ['amqp://localhost:5672'],
+          exchange: 'healthcheck.exchange',
+          routingKey: 'healthcheck.route',
+        },
+      });
+    });
+
+    it('keeps Kafka producerOnlyMode defaults unchanged', async () => {
+      await microservice.pingCheck('kafka', {
+        transport: Transport.KAFKA,
+        options: {
+          client: {
+            brokers: ['localhost:9092'],
+          },
+        },
+      });
+
+      expect(clientProxyFactoryMock.create).toHaveBeenCalledWith({
+        transport: Transport.KAFKA,
+        options: {
+          producerOnlyMode: true,
+          client: {
+            brokers: ['localhost:9092'],
+          },
+        },
+      });
+    });
+  });
+});

--- a/lib/health-indicator/microservice/microservice.health.ts
+++ b/lib/health-indicator/microservice/microservice.health.ts
@@ -19,7 +19,7 @@ import { HealthIndicatorService } from '../health-indicator.service';
 // That is why the user has to pass the options as Type Param.
 interface MicroserviceOptionsLike {
   transport?: number;
-  options?: object;
+  options?: Record<string, any>;
 }
 
 /**
@@ -72,6 +72,31 @@ export class MicroserviceHealthIndicator {
     return await checkConnection();
   }
 
+  private setRmqHealthCheckDefaults(
+    options: MicroserviceHealthIndicatorOptions<MicroserviceOptionsLike>,
+  ) {
+    if (options.transport !== this.nestJsMicroservices.Transport.RMQ) {
+      return;
+    }
+
+    const rmqOptions = options.options || {};
+
+    if (
+      'queue' in rmqOptions ||
+      'noAssert' in rmqOptions ||
+      'queueOptions' in rmqOptions ||
+      'exchange' in rmqOptions ||
+      'routingKey' in rmqOptions
+    ) {
+      return;
+    }
+
+    options.options = {
+      ...rmqOptions,
+      noAssert: true,
+    };
+  }
+
   /**
    * Checks if the given microservice is up
    * @param key The key which will be used for the result object
@@ -94,6 +119,8 @@ export class MicroserviceHealthIndicator {
   ): Promise<HealthIndicatorResult<Key>> {
     const check = this.healthIndicatorService.check(key);
     const timeout = options.timeout || 1000;
+
+    this.setRmqHealthCheckDefaults(options);
 
     if (options.transport === this.nestJsMicroservices.Transport.KAFKA) {
       options.options = {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/terminus/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #2680

`MicroserviceHealthIndicator.pingCheck` with `Transport.RMQ` and no `queue` specified creates a new RabbitMQ connection and calls `assertQueue` with whatever default queue name/options `@nestjs/microservices`' RMQ client falls back to. Depending on the version, that default queue name can be an empty string, which tells RabbitMQ to generate a fresh server-side queue name on every call. Verified this directly against a real broker: calling `channel.assertQueue('', {})` three times produced three distinct queues (`amq.gen-3T8sSiwFKQdPlXlClsU9gQ`, `amq.gen-uAM4xsfWRz42cY6qBmG7LQ`, `amq.gen-D5OdeGwtldapdHgI8p0I5A`), each `durable: true, auto_delete: false, exclusive: false` - i.e. they persist in RabbitMQ forever once the health-check connection closes. Since a health check reconnects on every `pingCheck` call, every health check tick leaves one more orphaned durable queue behind, eventually overloading RabbitMQ.

## What is the new behavior?

`pingCheck` now defaults `noAssert: true` for RMQ options when the caller hasn't specified `queue`, `noAssert`, `queueOptions`, `exchange`, or `routingKey` themselves. A plain connectivity check has no reason to declare a real queue at all, so this skips the `assertQueue` call entirely for the common case. If any of those options are explicitly set, that's treated as an opt-out and the caller's configuration is used as-is, unchanged.

## Verification

What I did and didn't verify:

- **The RabbitMQ-side mechanism** (empty queue name + default options → durable server-generated queue that outlives the connection) - verified directly with `amqplib` against a real broker, as described above.
- **The fix itself** - verified with a real RabbitMQ instance: ran the existing `RMQ > should connect` e2e test (uses default options, no `queue` specified) with this fix applied, then checked RabbitMQ's management API (`/api/queues`) afterward - empty, no queues left behind.
- **The option-merging logic** (respecting explicit `queue`/`noAssert`/`queueOptions`/`exchange`/`routingKey`, and leaving Kafka's existing defaults untouched) - covered by 6 new unit tests.
- **What I didn't do**: a single-environment before/after comparison against the exact `@nestjs/microservices` version the issue was filed against. The version installed in this repo is 11.0.11, whose default RMQ queue name is still the literal string `'default'` (asserting the same name repeatedly is idempotent, so it doesn't reproduce the queue accumulation on its own) rather than the empty-string default from the later version referenced in the issue. Verified the failure mechanism and the fix's effect independently instead of chaining them through the exact regressed dependency version in one run.

Full test suite (8 files, 77 tests) and lint pass.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

The only behavior change is for RMQ health checks that don't already specify `queue`/`noAssert`/`queueOptions`/`exchange`/`routingKey` - previously undefined/leaky behavior, not a documented contract.

## Other information
