### PR TITLE
fix(mongoose): use ping command for health check

### DIFF
--- a/lib/health-indicator/database/mongoose.health.spec.ts
+++ b/lib/health-indicator/database/mongoose.health.spec.ts
@@ -1,0 +1,75 @@
+import { type ModuleRef } from '@nestjs/core';
+import { HealthIndicatorService } from '../health-indicator.service';
+import { MongooseHealthIndicator } from './mongoose.health';
+
+describe('MongooseHealthIndicator', () => {
+  let mongooseHealthIndicator: MongooseHealthIndicator;
+
+  beforeEach(() => {
+    mongooseHealthIndicator = new MongooseHealthIndicator(
+      { get: jest.fn() } as unknown as ModuleRef,
+      new HealthIndicatorService(),
+    );
+  });
+
+  describe('#pingCheck', () => {
+    it('should execute a ping command against MongoDB', async () => {
+      const command = jest.fn().mockResolvedValue({ ok: 1 });
+      const connection = {
+        readyState: 1,
+        db: { command },
+      };
+
+      await expect(
+        mongooseHealthIndicator.pingCheck('mongo', { connection }),
+      ).resolves.toEqual({ mongo: { status: 'up' } });
+
+      expect(command).toHaveBeenCalledTimes(1);
+      expect(command).toHaveBeenCalledWith({ ping: 1 });
+    });
+
+    it('should report down when ping fails even if readyState is connected', async () => {
+      const command = jest
+        .fn()
+        .mockRejectedValue(new Error('server selection failed'));
+      const connection = {
+        readyState: 1,
+        db: { command },
+      };
+
+      await expect(
+        mongooseHealthIndicator.pingCheck('mongo', { connection }),
+      ).resolves.toEqual({ mongo: { status: 'down' } });
+    });
+
+    it('should report down when the database handle is unavailable', async () => {
+      const connection = { readyState: 1 };
+
+      await expect(
+        mongooseHealthIndicator.pingCheck('mongo', { connection }),
+      ).resolves.toEqual({ mongo: { status: 'down' } });
+    });
+
+    it('should report down when ping exceeds the configured timeout', async () => {
+      const command = jest
+        .fn()
+        .mockImplementation(() => new Promise(() => undefined));
+      const connection = {
+        readyState: 1,
+        db: { command },
+      };
+
+      await expect(
+        mongooseHealthIndicator.pingCheck('mongo', {
+          connection,
+          timeout: 10,
+        }),
+      ).resolves.toEqual({
+        mongo: {
+          message: 'timeout of 10ms exceeded',
+          status: 'down',
+        },
+      });
+    });
+  });
+});

--- a/lib/health-indicator/database/mongoose.health.ts
+++ b/lib/health-indicator/database/mongoose.health.ts
@@ -70,9 +70,11 @@ export class MongooseHealthIndicator {
    *
    */
   private async pingDb(connection: any, timeout: number) {
-    const promise =
-      connection.readyState === 1 ? Promise.resolve() : Promise.reject();
-    return await promiseTimeout(timeout, promise);
+    if (!connection.db) {
+      return Promise.reject();
+    }
+
+    return await promiseTimeout(timeout, connection.db.command({ ping: 1 }));
   }
 
   /**


### PR DESCRIPTION
PR Checklist
Please check if your PR fulfills the following requirements:
[x] The commit message follows our guidelines: https://github.com/nestjs/terminus/blob/master/CONTRIBUTING.md
[x] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)

PR Type
What kind of change does this PR introduce?
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:

What is the current behavior?
The Mongoose health indicator currently determines whether MongoDB is healthy by checking:
```ts
connection.readyState === 1
```
This only reflects the Mongoose connection state and does not verify that the MongoDB server is actually able to respond to commands.
In replica set scenarios, especially while a primary node is restarting or an election is in progress, `readyState` may remain `1` while database operations and commands are timing out.
As a result, the health indicator can report MongoDB as healthy even though the database is temporarily unavailable.
Issue Number: #2661

What is the new behavior?
The Mongoose health indicator now performs an actual MongoDB ping command:
```ts
connection.db.command({ ping: 1 })
```
The ping is still wrapped with the existing `promiseTimeout()` helper, so the configured health check timeout continues to be respected.
This makes the health check reflect whether MongoDB can actually respond instead of relying only on the local Mongoose connection state.
If the database handle is unavailable, the ping fails and the indicator reports the connection as down.

Tests
Added unit tests covering the following cases:
MongoDB successfully responds to `{ ping: 1 }` and the health indicator reports `up`
the Mongoose connection has `readyState: 1`, but the MongoDB ping fails, and the indicator correctly reports `down`
the connection does not expose a database handle and the indicator reports `down`
the MongoDB ping exceeds the configured timeout and the indicator reports `down` with the timeout message
The regression test for a connected `readyState` with a failing ping specifically covers the false-positive scenario described in #2661.

Does this PR introduce a breaking change?
[ ] Yes
[x] No
The public API remains unchanged.
`MongooseHealthIndicator.pingCheck()` keeps the same signature and timeout behavior. The difference is that the health status is now based on an actual MongoDB command instead of only checking the Mongoose connection state.

Other information
The TypeORM health indicator in Terminus already uses a MongoDB `{ ping: 1 }` command for MongoDB connections, so this change also makes the Mongoose health check behavior more consistent with the existing database health indicators.
Closes #2661